### PR TITLE
@orta: initial basic styles via albers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'braque'
 gem 'haml'
 gem 'simple_form'
 
+gem 'albers', git: 'https://github.com/dylanfareed/albers'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/dylanfareed/albers
+  revision: bdf9b72070c72024140d43b845c7dbd91e12d505
+  specs:
+    albers (0.1.0)
+      bourbon
+      neat
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,10 +48,13 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    arel (6.0.0)
+    arel (6.0.2)
     ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    bourbon (4.2.3)
+      sass (~> 3.4)
+      thor
     braque (0.0.8)
       active_attr (= 0.8.5)
       activesupport (~> 4.2)
@@ -51,7 +62,7 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    capybara (2.3.0)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -78,7 +89,7 @@ GEM
       net-http-digest_auth (~> 1.4)
     faraday_hal_middleware (0.0.1)
       faraday_middleware (>= 0.9, < 0.10)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.9.2)
       faraday (>= 0.7.4, < 0.10)
     futuroscope (0.1.11)
     globalid (0.3.5)
@@ -107,10 +118,13 @@ GEM
     mini_portile (0.6.2)
     minitest (5.7.0)
     multipart-post (2.0.0)
+    neat (1.7.2)
+      bourbon (>= 4.0)
+      sass (>= 3.3)
     net-http-digest_auth (1.4)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    parser (2.2.2.5)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
     rack (1.6.4)
@@ -142,15 +156,15 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
-    rspec-core (3.3.1)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.1)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-rails (3.3.2)
+    rspec-rails (3.3.3)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
@@ -167,7 +181,7 @@ GEM
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
-    sass (3.4.15)
+    sass (3.4.16)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -204,6 +218,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  albers!
   braque
   byebug
   capybara
@@ -219,3 +234,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   webmock (= 1.17.4)
+
+BUNDLED WITH
+   1.10.4

--- a/app/assets/stylesheets/local.scss
+++ b/app/assets/stylesheets/local.scss
@@ -1,0 +1,11 @@
+@import 'albers/base';
+
+section#main {
+  @include outer-container;
+  padding: $spacing-unit;
+}
+
+h2 {
+  @extend .single-padding-top;
+  font-size: 37px;
+}

--- a/app/views/accounts/_section_nav.haml
+++ b/app/views/accounts/_section_nav.haml
@@ -1,7 +1,8 @@
 - content_for :title do
   =link_to @account.name, account_path(@account)
 
-%ul
-  %li= link_to 'Features', account_features_path(account), class: (['features'].include? controller.controller_name) ? 'active' : ''
-  %li= link_to 'Messages', account_messages_path(account), class: (['messages'].include? controller.controller_name) ? 'active' : ''
-  %li= link_to 'Routes', account_routes_path(account), class: (['routes'].include? controller.controller_name) ? 'active' : ''
+%ul.tabs
+  %li= link_to 'Overview', account_path(account), class: (['accounts'].include? controller.controller_name) ? 'is-active' : ''
+  %li= link_to 'Features', account_features_path(account), class: (['features'].include? controller.controller_name) ? 'is-active' : ''
+  %li= link_to 'Messages', account_messages_path(account), class: (['messages'].include? controller.controller_name) ? 'is-active' : ''
+  %li= link_to 'Routes', account_routes_path(account), class: (['routes'].include? controller.controller_name) ? 'is-active' : ''

--- a/app/views/accounts/edit.haml
+++ b/app/views/accounts/edit.haml
@@ -2,4 +2,4 @@
 
 = simple_form_for :account, method: :patch, url: account_path(@account) do |f|
   = f.input :name
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/features/edit.haml
+++ b/app/views/accounts/features/edit.haml
@@ -3,4 +3,4 @@
 = simple_form_for :feature, method: :patch, url: account_feature_path(@account, @feature) do |f|
   = f.input :name, as: :string
   = f.input :value, as: :string
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/features/index.haml
+++ b/app/views/accounts/features/index.haml
@@ -1,7 +1,24 @@
 = render partial: '/accounts/section_nav', locals: { account: @account }
 
-= link_to t('actions.new'), new_account_feature_path(@account)
+.tab-actions
+  = link_to t('actions.new'), new_account_feature_path(@account), class: 'btn btn-primary btn-tiny'
 
-%ul
+%table
+  %tr
+    %th Name
+    %th Value
+    %th
   - @features.each do |feature|
-    %li=link_to feature.name, account_feature_path(@account, feature)
+    %tr
+      %td=link_to feature.name, account_feature_path(@account, feature)
+      %td=link_to "#{feature.value}", account_feature_path(@account, feature)
+      %td.actions
+        = link_to t('actions.edit'), edit_account_feature_path(@account, feature), class: 'btn btn-secondary btn-tiny'
+        = link_to t('actions.delete'), account_feature_path(@account, feature), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-delete btn-tiny'
+
+- if @features.try(:next_link) || @features.try(:previous_link)
+  .list-pager
+    - if @features.try(:previous_link)
+      = link_to 'Previous', account_features_path(@account, size: @size, page: @page - 1), class: 'list-pager-prev'
+    - if @features.try(:next_link)
+      = link_to 'Next', account_features_path(@account, size: @size, page: @page + 1), class: 'list-pager-next'

--- a/app/views/accounts/features/new.haml
+++ b/app/views/accounts/features/new.haml
@@ -3,4 +3,4 @@
 = simple_form_for :feature, url: account_features_path(@account) do |f|
   = f.input :name, as: :string
   = f.input :value, as: :string
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/index.haml
+++ b/app/views/accounts/index.haml
@@ -1,9 +1,15 @@
 - content_for :title do
   = t('.title')
 
-%p
-  = link_to t('actions.new'), new_account_path
+= link_to t('actions.new'), new_account_path, class: 'btn btn-primary btn-small'
 
-%ul
+%table
+  %tr
+    %th Name
+    %th
   - @accounts.each do |account|
-    %li=link_to account.name, account_path(account)
+    %tr
+      %td=link_to account.name, account_path(account)
+      %td.actions
+        = link_to t('actions.edit'), edit_account_path(account), class: 'btn btn-secondary btn-tiny'
+        = link_to t('actions.delete'), account_path(account), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-delete btn-tiny'

--- a/app/views/accounts/messages/edit.haml
+++ b/app/views/accounts/messages/edit.haml
@@ -2,5 +2,5 @@
 
 = simple_form_for :message, method: :patch, url: account_message_path(@account, @message) do |f|
   = f.input :name, as: :string
-  = f.input :content, as: :string
-  = f.button :submit, t('forms.save')
+  = f.input :content, as: :text
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/messages/index.haml
+++ b/app/views/accounts/messages/index.haml
@@ -1,7 +1,24 @@
 = render partial: '/accounts/section_nav', locals: { account: @account }
 
-= link_to t('actions.new'), new_account_message_path(@account)
+.tab-actions
+  = link_to t('actions.new'), new_account_message_path(@account), class: 'btn btn-primary btn-tiny'
 
-%ul
+%table
+  %tr
+    %th Name
+    %th Content
+    %th
   - @messages.each do |message|
-    %li=link_to message.name, account_message_path(@account, message)
+    %tr
+      %td=link_to message.name, account_message_path(@account, message)
+      %td=link_to truncate(message.content), account_message_path(@account, message)
+      %td.actions
+        = link_to t('actions.edit'), edit_account_message_path(@account, message), class: 'btn btn-secondary btn-tiny'
+        = link_to t('actions.delete'), account_message_path(@account, message), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-delete btn-tiny'
+
+- if @messages.try(:next_link) || @messages.try(:previous_link)
+  .list-pager
+    - if @messages.try(:previous_link)
+      = link_to 'Previous', account_messages_path(@account, size: @size, page: @page - 1), class: 'list-pager-prev'
+    - if @messages.try(:next_link)
+      = link_to 'Next', account_messages_path(@account, size: @size, page: @page + 1), class: 'list-pager-next'

--- a/app/views/accounts/messages/new.haml
+++ b/app/views/accounts/messages/new.haml
@@ -2,5 +2,5 @@
 
 = simple_form_for :message, url: account_messages_path(@account) do |f|
   = f.input :name, as: :string
-  = f.input :content, as: :string
-  = f.button :submit, t('forms.save')
+  = f.input :content, as: :text
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/new.haml
+++ b/app/views/accounts/new.haml
@@ -3,4 +3,4 @@
 
 = simple_form_for :account, url: accounts_path do |f|
   = f.input :name, as: :string
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/routes/edit.haml
+++ b/app/views/accounts/routes/edit.haml
@@ -3,4 +3,4 @@
 = simple_form_for :route, method: :patch, url: account_route_path(@account, @route) do |f|
   = f.input :name, as: :string
   = f.input :path, as: :string
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/routes/index.haml
+++ b/app/views/accounts/routes/index.haml
@@ -1,7 +1,24 @@
 = render partial: '/accounts/section_nav', locals: { account: @account }
 
-= link_to t('actions.new'), new_account_route_path(@account)
+.tab-actions
+  = link_to t('actions.new'), new_account_route_path(@account), class: 'btn btn-primary btn-tiny'
 
-%ul
+%table
+  %tr
+    %th Name
+    %th Path
+    %th
   - @routes.each do |route|
-    %li=link_to route.name, account_route_path(@account, route)
+    %tr
+      %td=link_to route.name, account_route_path(@account, route)
+      %td=link_to truncate(route.path), account_route_path(@account, route)
+      %td.actions
+        = link_to t('actions.edit'), edit_account_route_path(@account, route), class: 'btn btn-secondary btn-tiny'
+        = link_to t('actions.delete'), account_route_path(@account, route), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-delete btn-tiny'
+
+- if @routes.try(:next_link) || @routes.try(:previous_link)
+  .list-pager
+    - if @routes.try(:previous_link)
+      = link_to 'Previous', account_routes_path(@account, size: @size, page: @page - 1), class: 'list-pager-prev'
+    - if @routes.try(:next_link)
+      = link_to 'Next', account_routes_path(@account, size: @size, page: @page + 1), class: 'list-pager-next'

--- a/app/views/accounts/routes/new.haml
+++ b/app/views/accounts/routes/new.haml
@@ -3,4 +3,4 @@
 = simple_form_for :route, url: account_routes_path(@account) do |f|
   = f.input :name, as: :string
   = f.input :path, as: :string
-  = f.button :submit, t('forms.save')
+  = f.button :submit, t('forms.save'), class: 'btn btn-primary btn-small'

--- a/app/views/accounts/show.haml
+++ b/app/views/accounts/show.haml
@@ -1,3 +1,3 @@
 = render partial: 'section_nav', locals: { account: @account }
-= link_to t('actions.edit'), edit_account_path(id: @account.id)
-= link_to t('actions.delete'), account_path(id: @account.id), method: :delete, data: { confirm: "Are you sure?" }
+= link_to t('actions.edit'), edit_account_path(id: @account.id), class: 'btn btn-secondary btn-small'
+= link_to t('actions.delete'), account_path(id: @account.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-delete btn-small'

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,2 +1,3 @@
 = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
+= stylesheet_link_tag '//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css'
 = javascript_include_tag 'application', 'data-turbolinks-track' => true

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -1,2 +1,4 @@
-%ul
-  %li= link_to 'Echo', root_url
+%header.navigation
+  = link_to render(partial: '/shared/albers/svgs/mark'), root_url
+  %ul
+    %li= link_to 'Echo', root_url

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,7 @@
     = csrf_meta_tag
 
   %body{ class: "#{controller.controller_name}_#{controller.action_name}" }
-    %header.navigation
-      = render partial: 'layouts/nav'
+    = render partial: 'layouts/nav'
     %section#main
       = render partial: 'layouts/title'
       = render partial: 'layouts/flash'


### PR DESCRIPTION
We have a couple styleguide-like projects in use by teams internally. Though they are actively being worked on, neither are in a OS-ready state for the moment. 

In the interests of getting this app to a usable place, I've put a super minimal library together called [Albers](https://github.com/dylanfareed/albers)--based on [Bourbon](http://bourbon.io/) and [Neat](http://neat.bourbon.io/)--that works with Rails and Middleman apps. Albers provides bare minimum of coverage, but that's more than enough for the internal/trivial toolset that is Echo.

![image](https://cloud.githubusercontent.com/assets/197336/8768055/3a04be08-2e40-11e5-9879-3ea18fe84f34.png)

![image](https://cloud.githubusercontent.com/assets/197336/8768057/464b72f6-2e40-11e5-89ed-ebcbdf2bb54e.png)

![image](https://cloud.githubusercontent.com/assets/197336/8768075/25e6fce6-2e41-11e5-8961-58a8f88e8e1b.png)
